### PR TITLE
Add Dockerfile for Ruby CLI tool na

### DIFF
--- a/na-cli/Dockerfile
+++ b/na-cli/Dockerfile
@@ -1,8 +1,11 @@
 FROM ruby:3.3.0-slim-bookworm
 RUN apt-get -y update && apt-get -y install vim less && apt-get clean
 RUN gem install na
-ENV EDITOR vim
-WORKDIR /tasks
+RUN groupadd -g 1000 slowe
+RUN useradd -d /home/slowe -g 1000 -m -u 1000 slowe
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod a+x /usr/local/bin/entrypoint.sh
+USER slowe
+WORKDIR /home/slowe
+ENV EDITOR vim
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/na-cli/Dockerfile
+++ b/na-cli/Dockerfile
@@ -3,4 +3,6 @@ RUN apt-get -y update && apt-get -y install vim less && apt-get clean
 RUN gem install na
 ENV EDITOR vim
 WORKDIR /tasks
-CMD /usr/local/bundle/bin/na
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod a+x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/na-cli/Dockerfile
+++ b/na-cli/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:3.3.0-slim-bookworm
+RUN apt-get -y update && apt-get -y install vim less && apt-get clean
+RUN gem install na
+ENV EDITOR vim
+WORKDIR /tasks
+CMD /usr/local/bundle/bin/na

--- a/na-cli/README.md
+++ b/na-cli/README.md
@@ -1,0 +1,3 @@
+# Docker Container for `na` CLI Tool
+
+This directory contains a `Dockerfile` for containerizing [the `na` tool](https://brettterpstra.com/projects/na/) from Brett Terpstra (here's [the GH repo](https://github.com/ttscoff/na_gem/) for `na`).

--- a/na-cli/entrypoint.sh
+++ b/na-cli/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bundle/bin/na "$@"


### PR DESCRIPTION
The Ruby CLI tool `na` makes it easier to work with plain-text task management (via TaskPaper-formatted files). This Dockerfile would containerize `na` so that it can be used without first installing all of the Ruby dependencies.